### PR TITLE
Add options

### DIFF
--- a/tasks/delete_sync.js
+++ b/tasks/delete_sync.js
@@ -1,13 +1,14 @@
 module.exports = function(grunt) {
 
   grunt.registerMultiTask('delete_sync', 'Synchronize file deletion between two directories.', function() {
-
+    var options = this.options();
+    
     this.files.map(function(file) {
       file.src.map(function (val) {
         var targetFileName = file.cwd + '/' + val;
         if(grunt.file.isFile(targetFileName) && !grunt.file.exists(file.syncWith + '/' + val)) {
           grunt.log.writeln('Deleting file ' + targetFileName);
-          grunt.file.delete(targetFileName);
+          grunt.file.delete(targetFileName, options);
         }
       });
     });


### PR DESCRIPTION
Add the options object to the grunt.file.delete method.
Allow deletion outside the current working directory with the 'force' property.
